### PR TITLE
fix depth opt arg in totensor

### DIFF
--- a/generic/qttorch.cpp
+++ b/generic/qttorch.cpp
@@ -105,7 +105,7 @@ static int qttorch_(qimage_totensor)(lua_State *L)
   }
   else
   {
-    depth = luaL_optinteger(L, 2, 3);
+    depth = luaL_optinteger(L, 4, 3);
     if (depth != 1 && depth != 3 && depth != 4)
       luaL_error(L, "depth must be 1, 3, or 4.");
     if (depth == 1)

--- a/init.lua
+++ b/init.lua
@@ -6,11 +6,11 @@ qt.QImage.fromTensor = function(tensor, scale)
                           return tensor.qttorch.QImageFromTensor(tensor, scale)
                        end
 
-qt.QImage.toTensor = function(self, tensor, scale)
+qt.QImage.toTensor = function(self, tensor, scale, depth)
                         if type(tensor) == 'userdata' then
-                           return tensor.qttorch.QImageToTensor(self, tensor, scale)
+                           return tensor.qttorch.QImageToTensor(self, tensor, scale, depth)
                         else
                            local t = torch.getmetatable(torch.getdefaulttensortype())
-                           return t.qttorch.QImageToTensor(self, tensor, scale)
+                           return t.qttorch.QImageToTensor(self, tensor, scale, depth)
                         end
                      end


### PR DESCRIPTION
toTensor has a bug.  The optional `depth` parameter is hard coded as `narg=2`, which is actually the slot for the destination tensor.  `narg=1` is the `QImage` instance, `narg=2` is `Tdst` (tensor), `narg=3` is scale so `narg=4` should be the optional depth parameter.

I also added depth to the `toTensor` lua function if people (like myself) want to use it.
